### PR TITLE
Update Node version to LTS 18.16

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,7 +2,7 @@ pipeline:
   install:
     when:
       event: [push]
-    image: node:12.14-alpine
+    image: node:18.16-alpine
     commands:
       - npm install
       - npx lerna bootstrap
@@ -10,14 +10,14 @@ pipeline:
   build:
     when:
       event: [push]
-    image: node:12.14-alpine
+    image: node:18.16-alpine
     commands:
       - npx lerna run build
 
   publish:
     when:
       branch: master
-    image: node:12.14-alpine
+    image: node:18.16-alpine
     secrets: [ "npm_token" ]
     commands:
       - npm -v


### PR DESCRIPTION
Node 14 is EOL 30th of April 2023. This updates references to Node images < 14 to the LTS

[_Created by Sourcegraph batch change `rvu/node-14-eol`._](https://rvu.sourcegraph.com/organizations/rvu/batch-changes/node-14-eol)